### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
     "lowdb": "^0.13.1",
     "method-override": "^2.1.2",
     "morgan": "^1.3.1",
-    "node-uuid": "^1.4.2",
     "object-assign": "^4.0.1",
     "pluralize": "^3.0.0",
     "request": "^2.72.0",
     "server-destroy": "^1.0.1",
     "underscore-db": "^0.10.0",
     "update-notifier": "^1.0.2",
+    "uuid": "^3.0.0",
     "yargs": "^4.2.0"
   },
   "devDependencies": {

--- a/src/server/mixins.js
+++ b/src/server/mixins.js
@@ -1,4 +1,4 @@
-var uuid = require('node-uuid')
+var uuid = require('uuid')
 var pluralize = require('pluralize')
 
 module.exports = {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.